### PR TITLE
Lkd3063601 patch 3

### DIFF
--- a/QueueDemo/AckQueue.cs
+++ b/QueueDemo/AckQueue.cs
@@ -60,7 +60,7 @@ class AckQueue
                     queue.Acknowledge(mqMsg);
                 }
             }
-            catch (Exception e) { }
+            catch (Exception ex) { }
         }
 
         XTrace.WriteLine("Finish Consume");

--- a/QueueDemo/AckQueue.cs
+++ b/QueueDemo/AckQueue.cs
@@ -1,4 +1,4 @@
-﻿using NewLife.Caching;
+using NewLife.Caching;
 using NewLife.Log;
 using NewLife.Serialization;
 
@@ -46,9 +46,10 @@ class AckQueue
         var queue = redis.GetReliableQueue<String>(topic);
 
         XTrace.WriteLine("Start Consume");
-        try
+
+        while (!token.IsCancellationRequested)
         {
-            while (!token.IsCancellationRequested)
+            try
             {
                 var mqMsg = await queue.TakeOneAsync(10, token);
                 if (mqMsg != null)
@@ -59,8 +60,9 @@ class AckQueue
                     queue.Acknowledge(mqMsg);
                 }
             }
+            catch (OperationCanceledException) { }
         }
-        catch (OperationCanceledException) { }
+
         XTrace.WriteLine("Finish Consume");
     }
 }

--- a/QueueDemo/AckQueue.cs
+++ b/QueueDemo/AckQueue.cs
@@ -60,7 +60,7 @@ class AckQueue
                     queue.Acknowledge(mqMsg);
                 }
             }
-            catch (OperationCanceledException) { }
+            catch (Exception e) { }
         }
 
         XTrace.WriteLine("Finish Consume");

--- a/QueueDemo/DelayQueue.cs
+++ b/QueueDemo/DelayQueue.cs
@@ -62,7 +62,7 @@ class DelayQueue
                     queue.Acknowledge(mqMsg);
                 }
             }
-            catch (Exception e) { }
+            catch (Exception ex) { }
         }
 
         XTrace.WriteLine("Finish Consume");

--- a/QueueDemo/DelayQueue.cs
+++ b/QueueDemo/DelayQueue.cs
@@ -48,9 +48,10 @@ class DelayQueue
         var queue = redis.GetDelayQueue<String>(topic);
 
         XTrace.WriteLine("Start Consume");
-        try
+
+        while (!token.IsCancellationRequested)
         {
-            while (!token.IsCancellationRequested)
+            try
             {
                 var mqMsg = await queue.TakeOneAsync(10, token);
                 if (mqMsg != null)
@@ -61,8 +62,9 @@ class DelayQueue
                     queue.Acknowledge(mqMsg);
                 }
             }
+            catch (Exception e) { }
         }
-        catch (OperationCanceledException) { }
+
         XTrace.WriteLine("Finish Consume");
     }
 }

--- a/QueueDemo/EasyQueue.cs
+++ b/QueueDemo/EasyQueue.cs
@@ -44,9 +44,10 @@ class EasyQueue
     private static async Task Consume(IProducerConsumer<Area> queue, CancellationToken token)
     {
         XTrace.WriteLine("Start Consume");
-        try
+
+        while (!token.IsCancellationRequested)
         {
-            while (!token.IsCancellationRequested)
+            try
             {
                 var msg = await queue.TakeOneAsync(10, token);
                 if (msg != null)
@@ -54,8 +55,9 @@ class EasyQueue
                     XTrace.WriteLine("Consume {0} {1}", msg.Code, msg.Name);
                 }
             }
+            catch (OperationCanceledException) { }
         }
-        catch (OperationCanceledException) { }
+
         XTrace.WriteLine("Finish Consume");
     }
 }

--- a/QueueDemo/EasyQueue.cs
+++ b/QueueDemo/EasyQueue.cs
@@ -55,7 +55,7 @@ class EasyQueue
                     XTrace.WriteLine("Consume {0} {1}", msg.Code, msg.Name);
                 }
             }
-            catch (OperationCanceledException) { }
+            catch (Exception ex) { }
         }
 
         XTrace.WriteLine("Finish Consume");

--- a/QueueDemo/MemoryQueue.cs
+++ b/QueueDemo/MemoryQueue.cs
@@ -42,9 +42,10 @@ internal class MemoryQueue
     private static void Consume(BlockingCollection<Area> queue, CancellationToken token)
     {
         XTrace.WriteLine("Start Consume");
-        try
+
+        while (!token.IsCancellationRequested)
         {
-            while (!token.IsCancellationRequested)
+            try
             {
                 var msg = queue.Take(token);
                 if (msg != null)
@@ -52,8 +53,9 @@ internal class MemoryQueue
                     XTrace.WriteLine("Consume {0} {1}", msg.Code, msg.Name);
                 }
             }
+            catch (Exception ex) { }
         }
-        catch (OperationCanceledException) { }
+
         XTrace.WriteLine("Finish Consume");
     }
 }


### PR DESCRIPTION
修改 QueueDemo/AckQueue.cs、QueueDemo/DelayQueue.cs、QueueDemo/EasyQueue.cs、QueueDemo/MemoryQueue.cs文件：
修复ConsumeAsync 方法中 将while 外部try catch 改为里面 