### PR TITLE
修复超时时间没有默认值导致连接超时的bug

### DIFF
--- a/NewLife.Redis/RedisOptions.cs
+++ b/NewLife.Redis/RedisOptions.cs
@@ -25,6 +25,6 @@ public class RedisOptions
     /// <summary>超时时间。单位毫秒</summary>
     public Int32 Timeout { get; set; } = 3000;
 
-    /// <summary>键前缀,只适用于PrefixedRedis</summary>
+    /// <summary>键前缀</summary>
     public String? Prefix { get; set; }
 }

--- a/NewLife.Redis/RedisOptions.cs
+++ b/NewLife.Redis/RedisOptions.cs
@@ -23,7 +23,7 @@ public class RedisOptions
     public String? Password { get; set; }
 
     /// <summary>超时时间。单位毫秒</summary>
-    public Int32 Timeout { get; set; }
+    public Int32 Timeout { get; set; } = 3000;
 
     /// <summary>键前缀,只适用于PrefixedRedis</summary>
     public String? Prefix { get; set; }


### PR DESCRIPTION
修复超时时间没有默认值导致连接超时的bug
![image](https://github.com/NewLifeX/NewLife.Redis/assets/42953066/37555f5a-33ef-4424-ab25-b5366aae8644)
